### PR TITLE
added support for text line-height and allCaps filter

### DIFF
--- a/extension/jsx/utils/textHelper.jsx
+++ b/extension/jsx/utils/textHelper.jsx
@@ -30,15 +30,17 @@ var bm_textHelper = (function () {
             ob.sz = textDocument.boxTextSize;
             ob.ps = textDocument.boxTextPos;
         }
+
         var i, len;
         ob.s = textDocument.fontSize;
         ob.f = textDocument.font;
         bm_sourceHelper.addFont(textDocument.font, textDocument.fontFamily, textDocument.fontStyle);
-        ob.t = textDocument.text;
+        ob.t = textDocument.allCaps ? textDocument.text.toUpperCase() : textDocument.text; // text to caps if needed
         len = ob.t.length;
         bm_textShapeHelper.addTextLayer(layerInfo);
         ob.j = getJustification(textDocument.justification);
         ob.tr = textDocument.tracking;
+        ob.lh = textDocument.baselineLocs[5] - textDocument.baselineLocs[1]; // assume line height is same for each line of text
         if (textDocument.applyFill) {
             len = textDocument.fillColor.length;
             ob.fc = [];

--- a/extension/jsx/utils/textShapeHelper.jsx
+++ b/extension/jsx/utils/textShapeHelper.jsx
@@ -171,7 +171,8 @@ var bm_textShapeHelper = (function () {
             var fontFamily = textDocument.fontFamily;
             var fontStyle = textDocument.fontStyle;
             var fontSize = textDocument.fontSize;
-            var text = textDocument.text;
+            var text = textDocument.allCaps ? textDocument.text.toUpperCase() : textDocument.text;
+            
             var j, jLen = text.length;
             
             if (currentFont !== font) {

--- a/player/js/utils/DataManager.js
+++ b/player/js/utils/DataManager.js
@@ -370,7 +370,7 @@ function dataFunctionManager(){
         if(jLen === 0 && !('m' in data.t.p)){
             data.singleShape = true;
         }
-        documentData.yOffset = documentData.s*1.2;
+        documentData.yOffset = documentData.lh;
         documentData.ascent = fontData.ascent*documentData.s/100;
     }
 


### PR DESCRIPTION
textDocument.baselineLocs provides x,y coordinates of the beginning and end of each line in a text-box. We are assuming that each line in a tex-box will have the same line height. It is possible to support different line heights in the future. 
