### PR TITLE
bodymovin destroy fix

### DIFF
--- a/player/js/animation/AnimationManager.js
+++ b/player/js/animation/AnimationManager.js
@@ -144,7 +144,7 @@ var animationManager = (function(){
 
     function destroy(animation) {
         var i;
-        for(i=0;i<len;i+=1){
+        for(i=(len-1);i>=0;i-=1){
             registeredAnimations[i].animation.destroy(animation);
         }
     }


### PR DESCRIPTION
Counting should be done in reverse

Items are removed from the registeredAnimations array while the count goes up, this results into incorrect lookups in the array for nonexisting items