### PR TITLE
add some property to expression path and timeRemap key frame attributes

### DIFF
--- a/player/index.html
+++ b/player/index.html
@@ -94,6 +94,7 @@
     <script src="js/utils/expressions/Expressions.js" data-light-skip="true"></script>
     <script src="js/utils/expressions/ExpressionPropertyDecorator.js" data-light-skip="true"></script>
     <script src="js/utils/expressions/ExpressionManager.js" data-light-skip="true"></script>
+    <script src="js/utils/expressions/ExpressionProperties.js" data-light-skip="true"></script>
     <script src="js/utils/expressions/ShapeInterface.js" data-light-skip="true"></script>
     <script src="js/utils/expressions/TextInterface.js" data-light-skip="true"></script>
     <script src="js/utils/expressions/LayerInterface.js" data-light-skip="true"></script>
@@ -126,6 +127,7 @@
             progressiveLoad:false
         },
         path: 'exports/render/data.json'
+        // path: './data.json'
     };
     anim = bodymovin.loadAnimation(animData);
 

--- a/player/js/elements/canvasElements/CVCompElement.js
+++ b/player/js/elements/canvasElements/CVCompElement.js
@@ -34,7 +34,7 @@ function CVCompElement(data, comp,globalData){
     cv.height = this.data.h;
     this.canvas = cv;
     this.globalData = compGlobalData;
-    this.layers = data.layers;
+    this.layers = data.layers || [];
     this.pendingElements = [];
     this.elements = Array.apply(null,{length:this.layers.length});
     if(this.data.tm){

--- a/player/js/renderers/CanvasRenderer.js
+++ b/player/js/renderers/CanvasRenderer.js
@@ -233,6 +233,7 @@ CanvasRenderer.prototype.updateContainerSize = function () {
         this.transformCanvas.ty = 0;
     }
     this.transformCanvas.props = [this.transformCanvas.sx,0,0,0,0,this.transformCanvas.sy,0,0,0,0,1,0,this.transformCanvas.tx,this.transformCanvas.ty,0,1];
+    setTimeout(function() {this.animationItem.onTransformCanvas(this.transformCanvas)}.bind(this), 0);
     var i, len = this.elements.length;
     for(i=0;i<len;i+=1){
         if(this.elements[i] && this.elements[i].data.ty === 0){
@@ -242,7 +243,7 @@ CanvasRenderer.prototype.updateContainerSize = function () {
 };
 
 CanvasRenderer.prototype.destroy = function () {
-    if(this.renderConfig.clearCanvas) {
+    if(this.renderConfig.clearCanvas && this.animationItem.wrapper) {
         this.animationItem.wrapper.innerHTML = '';
     }
     var i, len = this.layers ? this.layers.length : 0;

--- a/player/js/utils/expressions/ExpressionProperties.js
+++ b/player/js/utils/expressions/ExpressionProperties.js
@@ -1,0 +1,76 @@
+var makePathExpressionProperty = (function() {
+  return function(pathValue) {
+    var p = pathValue.keyframes;
+    if (p.__pathPropertyDefined) {
+      return p;
+    }
+    p.__pathPropertyDefined = true;
+    Object.defineProperty(p, 'key', {
+      get: function() {
+        var frameRate = pathValue.comp.globalData.frameRate;
+        return function(index) {
+          //this index starts from 1
+          var k = p[index - 1];
+          k.time = k.t / frameRate;
+          k.index = index;
+          if (index === p.length) {
+            k.value = p[index - 2].e;
+          } else {
+            k.value = k.s;
+          }
+          return k;
+        }
+      },
+    });
+    Object.defineProperty(p, 'numKeys', {
+      get: function() {
+        return p.length;
+      }
+    });
+    Object.defineProperty(p, 'value', {
+      get: function() {
+        return p;
+      }
+    });
+    return p;
+  };
+})();
+
+var makeTimeRemapExpressionProperty = (function() {
+  return function(tmValue) {
+    var p = tmValue.keyframes;
+    if (p.__tmPropertyDefined) {
+      return p;
+    }
+    p.__tmPropertyDefined = true;
+    Object.defineProperty(p, 'key', {
+      get: function() {
+        var frameRate = tmValue.comp.globalData.frameRate;
+        return function(index) {
+          //this index starts from 1
+          var k = p[index - 1];
+          k.time = k.t / frameRate;
+          //  console.log(`k.time=${k.time}, k.t=${k.t}, frameRate=${frameRate}`)
+          k.index = index;
+          if (index === p.length) {
+            k.value = p[index - 2].e;
+          } else {
+            k.value = k.s;
+          }
+          return k;
+        }
+      },
+    });
+    Object.defineProperty(p, 'numKeys', {
+      get: function() {
+        return p.length;
+      }
+    });
+    Object.defineProperty(p, 'value', {
+      get: function() {
+        return p;
+      }
+    });
+    return p;
+  }
+})();

--- a/player/js/utils/expressions/LayerInterface.js
+++ b/player/js/utils/expressions/LayerInterface.js
@@ -126,6 +126,12 @@ var LayerExpressionInterface = (function (){
             }
         });
 
+        Object.defineProperty(_thisLayerFunction, "timeRemap", {
+            get: function(){
+                return makeTimeRemapExpressionProperty(elem.tm);
+            }
+        });
+
         _thisLayerFunction.registerMaskInterface = _registerMaskInterface;
         _thisLayerFunction.registerEffectsInterface = _registerEffectsInterface;
         return _thisLayerFunction;

--- a/player/js/utils/expressions/ShapeInterface.js
+++ b/player/js/utils/expressions/ShapeInterface.js
@@ -759,7 +759,7 @@ var ShapeExpressionInterface = (function(){
             Object.defineProperty(interfaceFunction, 'path', {
                 get: function(){
                     if(prop.k){
-                        prop.getValue();
+                        return makePathExpressionProperty(prop)
                     }
                     return prop.v;
                     //return shape_pool.clone(prop.v);


### PR DESCRIPTION
According to [Expression language reference](https://helpx.adobe.com/after-effects/using/expression-language-reference.html), Key attribute object has three properties: time, index, and value properties. In this PR, I implement path-valued key and timeRemap-valued key.