### PR TITLE
addEventListener returns removal method

### DIFF
--- a/player/js/utils/common.js
+++ b/player/js/utils/common.js
@@ -115,6 +115,9 @@ function _addEventListener(eventName, callback){
     }
     this._cbs[eventName].push(callback);
 
+	return function() {
+		this.removeEventListener(eventName, callback);
+	}.bind(this);
 }
 
 function _removeEventListener(eventName,callback){


### PR DESCRIPTION
Hi there,

I'd like to propose this small addition to the addEventListener method. It now returns a function that will remove the listener that was just added.
This comes in handy when you add a bound method as a listener that you want to remove later on. Instead of needing to keep a reference to the bound method (you know, the result of function.bind()) and the eventName, this way you can just execute the returned function and be done with it.

(I nicked the idea from AngularJS, adding an event listener to a scope there also returns a similar function)

P.S. Bodymovin is an amazing piece of code. Many, many kudos to you people, thank very much for your hard work!