### PR TITLE
fix(test): prevent cannot find src of undefined err

### DIFF
--- a/player/js/module.js
+++ b/player/js/module.js
@@ -145,7 +145,7 @@
     if(standalone) {
         var scripts = document.getElementsByTagName('script');
         var index = scripts.length - 1;
-        var myScript = scripts[index];
+        var myScript = scripts[index] || { src: '' };
         var queryString = myScript.src.replace(/^[^\?]+\??/,'');
         renderer = getQueryVariable('renderer');
     }


### PR DESCRIPTION
A previous PR https://github.com/bodymovin/bodymovin/pull/374 made this fix in the build folder, so newer builds likely overwrote it.

I can't find any record of it ever being there, so I don't know if any version has the fix.

```js
git log --pretty=short -u -L 13426,13426:build/player/bodymovin.js
```

Hopefully, adding the change in `player/js/module.js` solves this.

**Reviewers**
- [ ] @bodymovin 
* * *

**PR Description from #374**
When you run a test runner, perhaps there is no document.getElementsByTagName('script'). bodymovin assumes it's existence by default, which fails certain test environments.

Solves Open Issue:
https://github.com/bodymovin/bodymovin/issues/173

Problem:
```js
var myScript = scripts[index];
var queryString = myScript.src.replace(/^[^\?]+\??/,'');
```

Solution:
```js
var myScript = scripts[index] || { src: '' };
var queryString = myScript.src.replace(/^[^\?]+\??/,'');
```