### PR TITLE
fix(error): set params called twice for dynamic imports

### DIFF
--- a/player/js/animation/AnimationItem.js
+++ b/player/js/animation/AnimationItem.js
@@ -30,6 +30,7 @@ var AnimationItem = function () {
     this.pendingSegment = false;
     this._idle = true;
     this.projectInterface = ProjectInterface();
+    this.hasSetParams = false;
 };
 
 AnimationItem.prototype.setParams = function(params) {
@@ -71,7 +72,8 @@ AnimationItem.prototype.setParams = function(params) {
     this.autoloadSegments = params.hasOwnProperty('autoloadSegments') ? params.autoloadSegments :  true;
     if(params.animationData){
         self.configAnimation(params.animationData);
-    }else if(params.path){
+        self.hasSetParams = true
+    }else if(params.path && !self.hasSetParams){
         if(params.path.substr(-4) != 'json'){
             if (params.path.substr(-1, 1) != '/') {
                 params.path += '/';


### PR DESCRIPTION
Since `bodymovin` is quite large, we dynamically import the module to avoid heavier bundle sizes.

```js
import animationJSON from './animations/animation.json'
...
  componentDidMount() {
    import('bodymovin')
      .then(bodymovin => {
          bodymovin
            .loadAnimation({
              container: document.getElementById('animation'),
              renderer: 'svg',
              loop: false,
              autoplay: true,
              animationData: animationJSON,
            })
            .setSpeed(0.7)
      })
      .catch(err => console.log(err))
  }

```

The animation would run correctly, but as it was finishing, I get this error in the browser.
<img width="412" alt="screen shot 2017-05-25 at 8 59 20 am" src="https://cloud.githubusercontent.com/assets/14946478/26458575/80ccd9cc-4128-11e7-8388-9f049184c14a.png">

Upon inspection, I discovered that `setParams` is called twice.
<img width="540" alt="screen shot 2015-12-31 at 4 09 04 pm" src="https://cloud.githubusercontent.com/assets/14946478/26458399/f9e7fcf2-4127-11e7-9551-f5132433401d.png">

So this adds a check to prevent parsing a parsed or non-existent JSON.


