### PR TITLE
Add GitHub Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,8 +2,10 @@
     This template is for bug reports. If you are reporting a bug, please answer all the questions below.
     If you are here for another reason (feature request, question, etc) please delete this template before continuing.
 
-    Note that leaving sections blank will make it difficult for us to troubleshoot, causing delays in our response,
+    Note that leaving sections blank will make it difficult for us to troubleshoot bugs, causing delays in our response,
     or result in closing this issue.
+
+    Please include screenshots where applicable.
 -->
 
 **Tell us about your environment**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+    This template is for bug reports. If you are reporting a bug, please answer all the questions below.
+    If you are here for another reason (feature request, question, etc) please delete this template before continuing.
+
+    Note that leaving sections blank will make it difficult for us to troubleshoot, causing delays in our response,
+    or result in closing this issue.
+-->
+
+**Tell us about your environment**
+
+* **Browser and Browser Version:**
+* **After Effects Version:**
+
+**What did you do? Please explain the steps you took before you encountered the problem.**
+
+**What did you expect to happen?**
+
+**What actually happened? Please include as much _relevant_ detail as possible.**
+
+**Please provide a download link to the After Effects file that demonstrates the problem.**


### PR DESCRIPTION
@bodymovin, you are constantly asking people to include the After Effects File in bug reports, so this Pull Request will automatically remind people every time they go to open an issue that they should include a download link to the After Effects file that demonstrates the problem, which will save you some time in your correspondence and get issues resolved faster.

Feel free to tweak the template anyway you like, I think the most important part is the request for the After Effects file.

