### PR TITLE
Add displayBlock to rendererSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ bodymovin.loadAnimation({
     scaleMode: 'noScale',
     clearCanvas: false,
     progressiveLoad: false, // Boolean, only svg renderer, loads dom elements when needed. Might speed up initialization for large number of elements.
-    hideOnTransparent: true //Boolean, only svg renderer, hides elements when opacity reaches 0 (defaults to true)
+    hideOnTransparent: true, //Boolean, only svg renderer, hides elements when opacity reaches 0 (defaults to true)
+    displayBlock: true
   }
 });
 ```

--- a/player/js/renderers/CanvasRenderer.js
+++ b/player/js/renderers/CanvasRenderer.js
@@ -4,7 +4,8 @@ function CanvasRenderer(animationItem, config){
         clearCanvas: (config && config.clearCanvas !== undefined) ? config.clearCanvas : true,
         context: (config && config.context) || null,
         progressiveLoad: (config && config.progressiveLoad) || false,
-        preserveAspectRatio: (config && config.preserveAspectRatio) || 'xMidYMid meet'
+        preserveAspectRatio: (config && config.preserveAspectRatio) || 'xMidYMid meet',
+        displayBlock: (config && config.displayBlock) || false
     };
     this.renderConfig.dpr = (config && config.dpr) || 1;
     if (this.animationItem.wrapper) {
@@ -144,6 +145,9 @@ CanvasRenderer.prototype.configAnimation = function(animData){
         this.animationItem.container.style.transformOrigin = this.animationItem.container.style.mozTransformOrigin = this.animationItem.container.style.webkitTransformOrigin = this.animationItem.container.style['-webkit-transform'] = "0px 0px 0px";
         this.animationItem.wrapper.appendChild(this.animationItem.container);
         this.canvasContext = this.animationItem.container.getContext('2d');
+        if(this.renderConfig.displayBlock) {
+            this.animationItem.container.style.display = 'block';
+        }
     }else{
         this.canvasContext = this.renderConfig.context;
     }

--- a/player/js/renderers/SVGRenderer.js
+++ b/player/js/renderers/SVGRenderer.js
@@ -9,7 +9,8 @@ function SVGRenderer(animationItem, config){
         preserveAspectRatio: (config && config.preserveAspectRatio) || 'xMidYMid meet',
         progressiveLoad: (config && config.progressiveLoad) || false,
         hideOnTransparent: (config && config.hideOnTransparent === false) ? false : true,
-        viewBoxOnly: (config && config.viewBoxOnly) || false
+        viewBoxOnly: (config && config.viewBoxOnly) || false,
+        displayBlock: (config && config.displayBlock) || false
     };
     this.globalData.renderConfig = this.renderConfig;
     this.elements = [];
@@ -55,6 +56,9 @@ SVGRenderer.prototype.configAnimation = function(animData){
         this.layerElement.setAttribute('height',animData.h);
         this.layerElement.style.width = '100%';
         this.layerElement.style.height = '100%';
+    }
+    if(this.renderConfig.displayBlock) {
+        this.layerElement.style.display = 'block';
     }
     this.layerElement.setAttribute('preserveAspectRatio',this.renderConfig.preserveAspectRatio);
     //this.layerElement.style.transform = 'translate3d(0,0,0)';


### PR DESCRIPTION
Adds an option to make the rendered SVG or canvas display as a block. Since `svg` and `canvas` elements display inline by default, some [odd rendering issues can occur](https://stackoverflow.com/questions/24626908/how-to-get-rid-of-extra-space-below-svg-in-div-element) in some cases.