### PR TITLE
Add className to rendererSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ bodymovin.loadAnimation({
     scaleMode: 'noScale',
     clearCanvas: false,
     progressiveLoad: false, // Boolean, only svg renderer, loads dom elements when needed. Might speed up initialization for large number of elements.
-    hideOnTransparent: true //Boolean, only svg renderer, hides elements when opacity reaches 0 (defaults to true)
+    hideOnTransparent: true, //Boolean, only svg renderer, hides elements when opacity reaches 0 (defaults to true)
+    className: 'some-css-class-name'
   }
 });
 ```

--- a/player/js/renderers/CanvasRenderer.js
+++ b/player/js/renderers/CanvasRenderer.js
@@ -4,7 +4,8 @@ function CanvasRenderer(animationItem, config){
         clearCanvas: (config && config.clearCanvas !== undefined) ? config.clearCanvas : true,
         context: (config && config.context) || null,
         progressiveLoad: (config && config.progressiveLoad) || false,
-        preserveAspectRatio: (config && config.preserveAspectRatio) || 'xMidYMid meet'
+        preserveAspectRatio: (config && config.preserveAspectRatio) || 'xMidYMid meet',
+        className: (config && config.className) || ''
     };
     this.renderConfig.dpr = (config && config.dpr) || 1;
     if (this.animationItem.wrapper) {
@@ -144,6 +145,9 @@ CanvasRenderer.prototype.configAnimation = function(animData){
         this.animationItem.container.style.transformOrigin = this.animationItem.container.style.mozTransformOrigin = this.animationItem.container.style.webkitTransformOrigin = this.animationItem.container.style['-webkit-transform'] = "0px 0px 0px";
         this.animationItem.wrapper.appendChild(this.animationItem.container);
         this.canvasContext = this.animationItem.container.getContext('2d');
+        if(this.renderConfig.className) {
+            this.animationItem.container.setAttribute('class', this.renderConfig.className);
+        }
     }else{
         this.canvasContext = this.renderConfig.context;
     }

--- a/player/js/renderers/HybridRenderer.js
+++ b/player/js/renderers/HybridRenderer.js
@@ -1,9 +1,12 @@
-function HybridRenderer(animationItem){
+function HybridRenderer(animationItem, config){
     this.animationItem = animationItem;
     this.layers = null;
     this.renderedFrame = -1;
     this.globalData = {
         frameNum: -1
+    };
+    this.renderConfig = {
+        className: (config && config.className) || ''
     };
     this.pendingElements = [];
     this.elements = [];
@@ -178,6 +181,9 @@ HybridRenderer.prototype.configAnimation = function(animData){
     this.resizerElem = resizerElem;
     styleDiv(resizerElem);
     resizerElem.style.transformStyle = resizerElem.style.webkitTransformStyle = resizerElem.style.mozTransformStyle = "flat";
+    if(this.renderConfig.className) {
+      wrapper.setAttribute('class', this.renderConfig.className);
+    }
     wrapper.appendChild(resizerElem);
 
     resizerElem.style.overflow = 'hidden';

--- a/player/js/renderers/SVGRenderer.js
+++ b/player/js/renderers/SVGRenderer.js
@@ -9,7 +9,8 @@ function SVGRenderer(animationItem, config){
         preserveAspectRatio: (config && config.preserveAspectRatio) || 'xMidYMid meet',
         progressiveLoad: (config && config.progressiveLoad) || false,
         hideOnTransparent: (config && config.hideOnTransparent === false) ? false : true,
-        viewBoxOnly: (config && config.viewBoxOnly) || false
+        viewBoxOnly: (config && config.viewBoxOnly) || false,
+        className: (config && config.className) || ''
     };
     this.globalData.renderConfig = this.renderConfig;
     this.elements = [];
@@ -55,6 +56,9 @@ SVGRenderer.prototype.configAnimation = function(animData){
         this.layerElement.setAttribute('height',animData.h);
         this.layerElement.style.width = '100%';
         this.layerElement.style.height = '100%';
+    }
+    if(this.renderConfig.className) {
+        this.layerElement.setAttribute('class', this.renderConfig.className);
     }
     this.layerElement.setAttribute('preserveAspectRatio',this.renderConfig.preserveAspectRatio);
     //this.layerElement.style.transform = 'translate3d(0,0,0)';


### PR DESCRIPTION
Adds an option to add a CSS class name to the outermost elements created by Bodymovin.

One issue this helps solve is some [odd rendering issues that can occur](https://stackoverflow.com/questions/24626908/how-to-get-rid-of-extra-space-below-svg-in-div-element) due to `svg` and `canvas` elements displaying inline by default. 

Replaces #673.